### PR TITLE
#84 [MODIFY] 회원가입 로직 중 누락된 조건처리 추가

### DIFF
--- a/src/contexts/SignupContext.jsx
+++ b/src/contexts/SignupContext.jsx
@@ -24,8 +24,6 @@ export function SignupContextProvider({ children }) {
   };
   const value = useMemo(() => ({ formData, updateFormData }), [formData]);
 
-  console.log(formData);
-
   return (
     <SignupContext.Provider value={value}>{children}</SignupContext.Provider>
   );

--- a/src/pages/SignUp/pages/BasicInformation/index.jsx
+++ b/src/pages/SignUp/pages/BasicInformation/index.jsx
@@ -23,6 +23,7 @@ import styles from './BasicInformation.module.css';
 export default function BasicInformation({ onPrev, onNext }) {
   const [rePassword, setRePassword] = useState('');
   const [nicknameCheckData, setNicknameCheckData] = useState({});
+  const [isNicknameLoading, setIsNicknameLoading] = useState(false);
   const { formData, updateFormData } = useSignupContext();
   const {
     email,
@@ -42,6 +43,7 @@ export default function BasicInformation({ onPrev, onNext }) {
   const isValid =
     email &&
     password &&
+    password === rePassword &&
     lastName &&
     firstName &&
     year &&
@@ -110,21 +112,28 @@ export default function BasicInformation({ onPrev, onNext }) {
                 name='nickname'
                 label='닉네임'
                 value={nickname}
-                updateValue={(event) => {
+                updateValue={async (event) => {
                   updateFormData(event);
-                  setNicknameCheckData((prev) => ({
+
+                  await setNicknameCheckData((prev) => ({
                     ...prev,
                     isSuccess: undefined,
                   }));
                 }}
                 placeholder='닉네임을 입력해 주세요'
                 onClick={async () => {
-                  const data = await checkNicknameDuplication({ nickname });
-
-                  setNicknameCheckData(data);
+                  try {
+                    setIsNicknameLoading(true);
+                    const data = await checkNicknameDuplication({ nickname });
+                    setNicknameCheckData(data);
+                  } catch (error) {
+                  } finally {
+                    setIsNicknameLoading(false);
+                  }
                 }}
                 buttonText='중복확인'
                 required
+                disabled={isNicknameLoading}
               />
               <Message
                 text={nicknameCheckData?.message}


### PR DESCRIPTION
## 🎯 관련 이슈

close #84

<br />

## 🚀 작업 내용

- 닉네임 중복 검사 시 로딩 상태일 때 버튼 비활성화
- password와 rePassword가 같아야 회원가입 버튼 활성화

<br />

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->

<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
