### PR TITLE
#109 [FIX] 게시글 상세 경로에 board 제거

### DIFF
--- a/src/components/Profile/index.jsx
+++ b/src/components/Profile/index.jsx
@@ -15,7 +15,7 @@ export default function Profile() {
   const { data } = useSuspenseQuery({
     queryKey: [QUERY_KEY.profile],
     queryFn: getProfile,
-    gcTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 60 * 5,
   });
   const { nickname } = data;
 

--- a/src/dummy/post.js
+++ b/src/dummy/post.js
@@ -1,7 +1,7 @@
 const title = '한국어 어학 스터디 그룹 모집! (초급/중급) 📚';
 const commentCount = 1;
-const date = '2024-11-20T02:00:00Z';
-const nickname = '눈송이';
+const createdAt = '2024-11-20T02:00:00Z';
+const authorName = '눈송이';
 const likeCount = 123;
 const profileUrl = undefined;
 const bookmarkCount = 27;
@@ -35,62 +35,23 @@ const content = `안녕하세요!
 감사합니다! 😊`;
 
 export const POSTS = [
-  { postId: 1, title, commentCount, date, nickname, likeCount },
-  { postId: 2, title, commentCount, date, nickname, likeCount },
-  { postId: 3, title, commentCount, date, nickname, likeCount },
-  { postId: 4, title, commentCount, date, nickname, likeCount },
-  { postId: 5, title, commentCount, date, nickname, likeCount },
-  { postId: 6, title, commentCount, date, nickname, likeCount },
-  { postId: 7, title, commentCount, date, nickname, likeCount },
-  { postId: 8, title, commentCount, date, nickname, likeCount },
-  { postId: 9, title, commentCount, date, nickname, likeCount },
-  { postId: 10, title, commentCount, date, nickname, likeCount },
-];
-
-export const MY_POSTS = [
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
-];
-
-export const BOOKMARK_POSTS = [
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
-];
-
-export const SEARCH_POSTS = [
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 1, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 2, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 3, title, commentCount, date, nickname, likeCount },
-  { boardId: 2, postId: 4, title, commentCount, date, nickname, likeCount },
-  { boardId: 1, postId: 5, title, commentCount, date, nickname, likeCount },
+  { postId: 1, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 2, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 3, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 4, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 5, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 6, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 7, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 8, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 9, title, commentCount, createdAt, authorName, likeCount },
+  { postId: 10, title, commentCount, createdAt, authorName, likeCount },
 ];
 
 export const POST = {
   title,
   profileUrl,
-  nickname,
-  date,
+  authorName,
+  createdAt,
   likeCount,
   bookmarkCount,
   content,

--- a/src/pages/Board/components/Posts/index.jsx
+++ b/src/pages/Board/components/Posts/index.jsx
@@ -4,8 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getPosts } from '@apis';
 
 import { Post } from '@components';
-
-import Path from '@utils/Path.js';
+import Path from '@utils/Path';
 import { QUERY_KEY } from '@constants';
 
 export default function Posts({ board }) {
@@ -24,10 +23,7 @@ export default function Posts({ board }) {
         <Post
           key={post.postId}
           post={post}
-          to={Path.getPostPath({
-            postId: post.postId,
-            boardId: id,
-          })}
+          to={Path.getPostPath({ postId: post.postId })}
         />
       ))}
     </ul>

--- a/src/pages/MyPage/components/BookmarkedPosts/index.jsx
+++ b/src/pages/MyPage/components/BookmarkedPosts/index.jsx
@@ -20,10 +20,7 @@ export default function BookmarkedPosts() {
         <Post
           key={post.postId}
           post={post}
-          to={Path.getPostPath({
-            postId: post.postId,
-            boardId: post.boardId,
-          })}
+          to={Path.getPostPath({ postId: post.postId })}
         />
       ))}
     </>

--- a/src/pages/MyPage/components/MyPosts/index.jsx
+++ b/src/pages/MyPage/components/MyPosts/index.jsx
@@ -20,10 +20,7 @@ export default function MyPosts() {
         <Post
           key={post.postId}
           post={post}
-          to={Path.getPostPath({
-            postId: post.postId,
-            boardId: post.boardId,
-          })}
+          to={Path.getPostPath({ postId: post.postId })}
         />
       ))}
     </>

--- a/src/pages/MyPage/index.jsx
+++ b/src/pages/MyPage/index.jsx
@@ -19,14 +19,11 @@ import { ReactComponent as BookIcon } from '@assets/book.svg';
 import { ReactComponent as CallIcon } from '@assets/call.svg';
 import { ReactComponent as SchoolIcon } from '@assets/school.svg';
 
-import { INFO, MY_POSTS, BOOKMARK_POSTS } from '@dummy';
+import { INFO } from '@dummy';
 
 import styles from './MyPage.module.css';
 
 export default function MyPage() {
-  const TOP5_MY_POSTS = MY_POSTS.slice(0, 5);
-  const TOP5_BOOKMARK_POSTS = BOOKMARK_POSTS.slice(0, 5);
-
   return (
     <section className={styles.container}>
       <ErrorBoundary FallbackComponent={ProfileErrorFallback}>

--- a/src/pages/Post/Post.module.css
+++ b/src/pages/Post/Post.module.css
@@ -1,10 +1,3 @@
-.loading {
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .container {
   margin: 70px 0 100px 0;
   display: flex;
@@ -26,25 +19,6 @@
   border: 1px solid var(--gray-scale-8);
   background: var(--gray-scale-9);
   box-shadow: 0px 5px 30px -15px rgba(0, 0, 0, 0.2);
-}
-
-.content {
-  margin: 35px 0 50px 0;
-  color: var(--gray-scale-1);
-  font-size: 18px;
-  font-weight: 300;
-  line-height: 26px;
-  letter-spacing: 0.72px;
-  white-space: pre-wrap;
-  word-break: keep-all;
-}
-
-.buttons {
-  padding: 50px 0;
-  display: flex;
-  justify-content: center;
-  gap: 42px;
-  border-bottom: 1px solid var(--gray-scale-7);
 }
 
 /* bottom */

--- a/src/pages/Post/components/BoardNavigationHeader/index.jsx
+++ b/src/pages/Post/components/BoardNavigationHeader/index.jsx
@@ -1,6 +1,5 @@
-import { useLocation, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
-import Path from '@utils/Path.js';
 import { ReactComponent as BackIcon } from '@assets/backArrow.svg';
 
 import styles from './BoardNavigationHeader.module.css';
@@ -8,19 +7,17 @@ import styles from './BoardNavigationHeader.module.css';
 const UNIV = 'Sookmyung Women’s Univ.';
 
 export default function BoardNavigationHeader() {
-  const { pathname } = useLocation();
-  const { path, name } = Path.getBoard(pathname);
+  const navigate = useNavigate();
+  const back = () => navigate(-1);
 
   return (
-    <Link to={path}>
-      <div className={styles.container}>
-        <div className={styles.navigator}>
-          <BackIcon width={14} height={14} />
-          <span className={styles.name}>
-            {UNIV} {name}
-          </span>
-        </div>
+    <div className={styles.container} onClick={back}>
+      <div className={styles.navigator}>
+        <BackIcon width={14} height={14} />
+        <span className={styles.name}>
+          {UNIV} {name}
+        </span>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/src/pages/Post/components/Content/Content.module.css
+++ b/src/pages/Post/components/Content/Content.module.css
@@ -1,0 +1,18 @@
+.content {
+  margin: 35px 0 50px 0;
+  color: var(--gray-scale-1);
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 26px;
+  letter-spacing: 0.72px;
+  white-space: pre-wrap;
+  word-break: keep-all;
+}
+
+.buttons {
+  padding: 50px 0;
+  display: flex;
+  justify-content: center;
+  gap: 42px;
+  border-bottom: 1px solid var(--gray-scale-7);
+}

--- a/src/pages/Post/components/Content/ContentErrorFallback.jsx
+++ b/src/pages/Post/components/Content/ContentErrorFallback.jsx
@@ -1,0 +1,15 @@
+import { ServerErrorFallback } from '@components';
+
+export default function ContentErrorFallback({ error, resetErrorBoundary }) {
+  const { status } = error;
+
+  if (status === 401) {
+    alert('로그인 후 이용 가능합니다.');
+  }
+
+  if (status === 404) {
+    alert('존재하지 않는 게시글입니다');
+  }
+
+  return <ServerErrorFallback reset={resetErrorBoundary} />;
+}

--- a/src/pages/Post/components/Content/index.jsx
+++ b/src/pages/Post/components/Content/index.jsx
@@ -1,0 +1,41 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { usePost } from '@hooks';
+import { PostHeader, BookmarkButton, LikeButton } from '@pages/Post/components';
+import { QUERY_KEY } from '@constants';
+
+import styles from './Content.module.css';
+
+export default function Content() {
+  const navigate = useNavigate();
+  const { postId } = useParams();
+  const { getPost } = usePost();
+
+  const { data: post } = useSuspenseQuery({
+    queryKey: [QUERY_KEY.post, postId],
+    queryFn: getPost,
+  });
+
+  const {
+    content,
+    isLiked,
+    likeCount,
+    isBookmarked,
+    bookmarkCount,
+    commentCount,
+  } = post;
+
+  console.log(post);
+
+  return (
+    <div className={styles.top}>
+      <PostHeader post={post} />
+      <p className={styles.content}>{content}</p>
+      <div className={styles.buttons}>
+        <LikeButton liked={isLiked} count={likeCount} />
+        <BookmarkButton bookmarked={isBookmarked} count={bookmarkCount} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Post/components/index.js
+++ b/src/pages/Post/components/index.js
@@ -1,6 +1,8 @@
 export { default as ActionButton } from '@pages/Post/components/ActionButton';
 export { default as BoardNavigationHeader } from '@pages/Post/components/BoardNavigationHeader';
 export { default as BookmarkButton } from '@pages/Post/components/BookmarkButton';
+export { default as Content } from '@pages/Post/components/Content';
+export { default as ContentErrorFallback } from '@pages/Post/components/Content/ContentErrorFallback';
 export { default as Comment } from '@pages/Post/components/Comment';
 export { default as Comments } from '@pages/Post/components/Comments';
 export { default as CommentsErrorFallback } from '@pages/Post/components/Comments/CommentsErrorFallback';

--- a/src/pages/Post/index.jsx
+++ b/src/pages/Post/index.jsx
@@ -1,112 +1,79 @@
-import { Suspense } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { Suspense, startTransition } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { useQuery, QueryErrorResetBoundary } from '@tanstack/react-query';
-
-import { usePost } from '@hooks';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
 import ErrorPage from '@pages/ErrorPage';
-import { Profile, Loading } from '@components';
+import { Profile, ProfileErrorFallback, Loading } from '@components';
 import {
   BoardNavigationHeader,
-  BookmarkButton,
+  Content,
+  ContentErrorFallback,
   Comments,
   CommentsErrorFallback,
   CommentInput,
-  LikeButton,
-  PostHeader,
 } from '@pages/Post/components';
 
-import { QUERY_KEY } from '@constants';
 import { POST } from '@dummy';
 
 import styles from './Post.module.css';
 
-const { likeCount, bookmarkCount, commentCount } = POST;
+const { commentCount } = POST;
 
 export default function Post() {
-  const navigate = useNavigate();
-  const { postId } = useParams();
-  const { getPost } = usePost();
-
-  const {
-    data: post,
-    isPending,
-    error,
-  } = useQuery({
-    queryKey: [QUERY_KEY.post, postId],
-    queryFn: getPost,
-  });
-
-  if (isPending) {
-    return (
-      <section className={styles.loading}>
-        <Loading />
-      </section>
-    );
-  }
-
-  if (error) {
-    const { status } = error?.response ?? {};
-
-    if (error.code === 'ERR_NETWORK') {
-      alert('네트워크 에러!');
-    }
-
-    if (status === 401) {
-      alert('로그인이 필요한 서비스입니다');
-    }
-
-    if (status === 404) {
-      alert('존재하지 않는 게시글입니다');
-    }
-
-    if (status !== 401 && status !== 404 && error.code !== 'ERR_NETWORK') {
-      alert('잠시 후 다시 시도해주세요');
-    }
-
-    navigate(-1);
-
-    return null;
-  }
-
-  const { content, isLiked, likeCount, isBookmarked, bookmarkCount } = post;
-
   return (
     <section className={styles.container}>
-      <Profile />
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            onReset={reset}
+            FallbackComponent={ProfileErrorFallback}
+          >
+            <Suspense fallback={<Loading />}>
+              <Profile />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+
       <article className={styles.post}>
         <BoardNavigationHeader />
         <section className={styles.wrapper}>
-          <div className={styles.top}>
-            <PostHeader post={post} />
-            <p className={styles.content}>{content}</p>
-            <div className={styles.buttons}>
-              <LikeButton liked={isLiked} count={likeCount} />
-              <BookmarkButton bookmarked={isBookmarked} count={bookmarkCount} />
-            </div>
-          </div>
-          <div className={styles.bottom}>
-            <div className={styles.input}>
-              <p className={styles.commentLabel}>
-                댓글 <span className={styles.commentCount}>{commentCount}</span>
-              </p>
-              <CommentInput />
-            </div>
+          <QueryErrorResetBoundary>
+            {({ reset }) => (
+              <ErrorBoundary
+                FallbackComponent={ContentErrorFallback}
+                onReset={reset}
+              >
+                <Suspense fallback={<Loading />}>
+                  <Content />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
 
-            <QueryErrorResetBoundary>
-              {({ reset }) => (
-                <ErrorBoundary
-                  FallbackComponent={CommentsErrorFallback}
-                  onReset={reset}
-                >
-                  <Suspense fallback={<Loading />}>
+          <QueryErrorResetBoundary>
+            {({ reset }) => (
+              <ErrorBoundary
+                FallbackComponent={CommentsErrorFallback}
+                onReset={reset}
+              >
+                <Suspense fallback={<Loading />}>
+                  <div className={styles.bottom}>
+                    <div className={styles.input}>
+                      <p className={styles.commentLabel}>
+                        댓글{' '}
+                        <span className={styles.commentCount}>
+                          {commentCount}
+                        </span>
+                      </p>
+                      <CommentInput />
+                    </div>
                     <Comments />
-                  </Suspense>
-                </ErrorBoundary>
-              )}
-            </QueryErrorResetBoundary>
-          </div>
+                  </div>
+                </Suspense>
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
         </section>
       </article>
     </section>

--- a/src/routes.js
+++ b/src/routes.js
@@ -29,19 +29,11 @@ export const routes = [
         element: <Board />,
       },
       {
-        path: `${PATH.allBoard}${PATH.post}`,
+        path: PATH.post,
         element: <Post />,
       },
       {
-        path: `${PATH.internationalBoard}${PATH.post}`,
-        element: <Post />,
-      },
-      {
-        path: `${PATH.allBoard}${PATH.postCreation}`,
-        element: <PostCreation />,
-      },
-      {
-        path: `${PATH.internationalBoard}${PATH.postCreation}`,
+        path: PATH.postCreation,
         element: <PostCreation />,
       },
       {

--- a/src/utils/Path.js
+++ b/src/utils/Path.js
@@ -12,11 +12,8 @@ class Path {
     return BOARDS.find(({ path }) => convertedPath.includes(path));
   }
 
-  static getPostPath({ postId, boardId }) {
-    const { path } = BOARDS.find((board) => board.id === boardId);
-    const postPath = PATH.post.replace(':postId', postId);
-
-    return `${path}${postPath}`;
+  static getPostPath({ postId }) {
+    return `/post/${postId}`;
   }
 }
 


### PR DESCRIPTION
## 🎯 관련 이슈

close #109

<br />

## 🚀 작업 내용

- 프론트에서는 board id를 통해 게시글 상세 라우트를 처리하지만, 서버에서 board 데이터를 내려주지 않아 발생한 버그
- 프론트에서 board id를 사용하지 않는 로직으로 수정

<!--
## 📸 스크린샷

| (스크린샷을 넣어주세요) |
| :---------------------: |

<br />
-->

<!--
## 🔎 발견된 장애가 있었나요?

- (어떤 장애가 발견되었는지 작성해주세요.)
- (어떻게 해결했는지도 작성해주세요.)

<br />
-->

<!--
## 💡 어떻게 해결했나요?

- (버그 해결 방법 및 과정을 작성해주세요.)

<br />
-->

<!--
## 🙋🏻‍♀️ 리뷰어가 어떤 부분에 집중해야 할까요?

<br />
-->
